### PR TITLE
swap chowlk dependency from direct git+https to unofficial pypi release

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -20,7 +20,7 @@ classifiers =
 packages = find:
 install_requires =
     beautifulsoup4==4.11.2
-    chowlk@git+https://github.com/pablo-de-andres/Chowlk@02a6820eb07e36e40ae17702672ca59af561f922
+    chowlk-unofficial-fork==0.0.2
     openpyxl==3.1.1
     pandas==1.5.3
     python-dotenv==0.21.1


### PR DESCRIPTION
* for initial release of data2rdf on pypi.