### PR TITLE
Fix/magic windows

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,13 @@ In windows it might be necessary to install curses manually. This can be done wi
 pip install windows-curses
 ```
 
+Another **critical** dependency is the Python-binary for `magic` under Windows:
+
+```
+pip install python-magic-bin
+```
+
+
 ## Debug a Chowlk XML File
 
 In some cases when the syntax of the draw.io file is not correct (e.g.: missing label on arrow, bracket in class file) chowlk crashes. The only (pretty annoying but working) way to find the wrong syntax is to execute chowlk with the command line for that file and inclemently remove elements from the draw.io diagram. This way you can find the wrong syntax by process of elimination.

--- a/data2rdf/csv_parser.py
+++ b/data2rdf/csv_parser.py
@@ -73,9 +73,8 @@ class CSVParser:
         Get file encoding
         """
         rawdata = open(self.f_path, "rb").read()
-        buffered = magic.open(magic.MAGIC_MIME_ENCODING)
-        buffered.load()
-        self.encoding = buffered.buffer(rawdata)
+        buffered = magic.Magic(mime_encoding=True)
+        self.encoding = buffered.from_buffer(rawdata)
 
     def load_file(self):
         self.file = open(self.f_path, encoding=self.encoding).read()

--- a/data2rdf/csv_parser.py
+++ b/data2rdf/csv_parser.py
@@ -1,6 +1,4 @@
-import hashlib
-import io
-
+import uuid
 import magic
 import pandas as pd
 
@@ -138,10 +136,7 @@ class CSVParser:
         self.column_df.index.name = "index"
 
     def generate_file_uuid(self):
-        # add file_uuid using unique hashsum of the file
-        # with open(f_path, 'r', encoding=encoding) as file:
-        text = self.file.encode()
-        self.id_hash = hashlib.md5(text).hexdigest()
+        self.id_uuid = str(uuid.uuid4())
 
     def generate_file_meta_df(self):
         self.file_meta_df = pd.Series()
@@ -152,7 +147,7 @@ class CSVParser:
         self.file_meta_df["file_path"] = self.f_path
         self.file_meta_df["server_file_path"] = self.server_f_path
         self.file_meta_df["namespace"] = self.namespace
-        self.file_meta_df["uuid"] = self.id_hash
+        self.file_meta_df["uuid"] = self.id_uuid
 
         self.file_meta_df = pd.DataFrame(self.file_meta_df)
         self.file_meta_df.columns = ["value"]

--- a/data2rdf/csv_parser.py
+++ b/data2rdf/csv_parser.py
@@ -1,7 +1,7 @@
 import uuid
 import magic
 import pandas as pd
-
+import io
 
 class CSVParser:
 

--- a/data2rdf/csv_parser.py
+++ b/data2rdf/csv_parser.py
@@ -1,7 +1,9 @@
+import io
 import uuid
+
 import magic
 import pandas as pd
-import io
+
 
 class CSVParser:
 

--- a/data2rdf/excel_parser.py
+++ b/data2rdf/excel_parser.py
@@ -2,6 +2,7 @@ import uuid
 
 import pandas as pd
 from openpyxl import load_workbook
+import io
 
 
 class ExcelParser:

--- a/data2rdf/excel_parser.py
+++ b/data2rdf/excel_parser.py
@@ -1,17 +1,7 @@
-import hashlib
+import uuid
 
 import pandas as pd
 from openpyxl import load_workbook
-
-
-def sha256sum(filename):
-    h = hashlib.sha256()
-    b = bytearray(128 * 1024)
-    mv = memoryview(b)
-    with open(filename, "rb", buffering=0) as f:
-        for n in iter(lambda: f.readinto(mv), 0):
-            h.update(mv[:n])
-    return h.hexdigest()
 
 
 class ExcelParser:
@@ -236,8 +226,7 @@ class ExcelParser:
     def generate_file_uuid(self):
         # add file_uuid using unique hashsum of the file
         # with open(f_path, 'r', encoding=encoding) as file:
-
-        self.id_hash = sha256sum(self.f_path)
+        self.id_uuid = str(uuid.uuid4())
 
     def generate_file_meta_df(self):
         self.file_meta_df = pd.Series()
@@ -248,7 +237,7 @@ class ExcelParser:
         self.file_meta_df["file_path"] = self.f_path
         self.file_meta_df["server_file_path"] = self.server_f_path
         self.file_meta_df["namespace"] = self.namespace
-        self.file_meta_df["uuid"] = self.id_hash
+        self.file_meta_df["uuid"] = self.id_uuid
 
         self.file_meta_df = pd.DataFrame(self.file_meta_df)
         self.file_meta_df.columns = ["value"]

--- a/data2rdf/excel_parser.py
+++ b/data2rdf/excel_parser.py
@@ -2,7 +2,6 @@ import uuid
 
 import pandas as pd
 from openpyxl import load_workbook
-import io
 
 
 class ExcelParser:


### PR DESCRIPTION

"@THuschle found a problem that Python-magic needs an extra library called "python-magic-bin" under Windows.

Related to that, the api of the package is a little bit different and hence needs to be adjusted, which has been done for this PR.

I also added some installation notes in case of Windows users" 
 
- Comment by  @MBueschelberger 