### PR TITLE
update file links in documentation

### DIFF
--- a/docs/examples/abox/1_csv.md
+++ b/docs/examples/abox/1_csv.md
@@ -25,7 +25,7 @@ The csv file produced by the tensile test machine looks like this:
 
 ![details](../../assets/img/docu/CSV-Parser.png)
 
-The original file can be accessed [here](https://raw.githubusercontent.com/MI-FraunhoferIWM/data2rdf/f9e5adfe2c18dd0bd4887bc685459671b1fbb29a/tests/csv_pipeline_test/input/data/DX56_D_FZ2_WR00_43.TXT). Due to clarify reasons, we truncated the time series in this document here.
+The original file can be accessed [here](https://github.com/MI-FraunhoferIWM/data2rdf/raw/bbde50919c50f3428eec179f94f29315f31165fe/tests/abox/csv_pipeline_test/input/data/DX56_D_FZ2_WR00_43.TXT). Due to clarify reasons, we truncated the time series in this document here.
 
 ```{note}
 We are strictly assuming that metadata is on top of the time series and has a the key-value-unit pattern. Therefore the metadata up to now needs to have a width of 2 to 3 columns. In the future, we may support extending the default width of the metadata, in case if we need to have a width of 4 or more columns, e.g. if there are be more concepts than just value and unit.

--- a/docs/examples/abox/2_excel.md
+++ b/docs/examples/abox/2_excel.md
@@ -33,7 +33,7 @@ The excel file produced by the tensile test machine looks like this:
 
 Again, we are facing metadata of the experiment like e.g. `Projekt`, `Prüfer`, `Werkstoff`, etc. and time series with the quantities of `Zeit`, `F`, `B`, which need to be mapped to ontological concepts.
 
-The original file can be accessed [here](https://github.com/MI-FraunhoferIWM/data2rdf/raw/enh/annotations/tests/abox/xls_pipeline_test/input/data/AFZ1-Fz-S1Q.xlsm).
+The original file can be accessed [here](https://github.com/MI-FraunhoferIWM/data2rdf/raw/bbde50919c50f3428eec179f94f29315f31165fe/tests/abox/xls_pipeline_test/input/data/AFZ1-Fz-S1Q.xlsm).
 
 
 ### The mapping


### PR DESCRIPTION
Previously, the links for the csv and excel tensile tests were referring to old commit hashes which were squashed while merging into the main branch. 

This has been solved by using the commit hash of the v2.0.0 release instead.