### PR TITLE
make sure iri gets stripped when assigned, add coverage reporting

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -23,7 +23,7 @@ jobs:
       - name: Set up Python 3.10
         uses: actions/setup-python@v2
         with:
-          python-version: 3.10
+          python-version: 3.10.0
 
       - name: Install package
         run: |

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -21,9 +21,12 @@ jobs:
       - uses: actions/checkout@v3
 
       - name: Set up Python 3.10
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v3
         with:
-          python-version: 3.10.0
+          python-version: '3.10'
+        #   architecture: 'x64' # optional x64 or x86. Defaults to x64 if not specified
+        # env:
+        #   AGENT_TOOLSDIRECTORY: /opt/hostedtoolcache
 
       - name: Install package
         run: |

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -35,7 +35,7 @@ jobs:
 
       - name: Build coverage file
         run: |
-          pytest --junitxml=pytest.xml --cov-report=term-missing:skip-covered --cov=app tests/ | tee pytest-coverage.txt
+          pytest --junitxml=pytest.xml  --cov=data2rdf | tee pytest-coverage.txt
 
       - name: Pytest coverage comment
         uses: MishaKav/pytest-coverage-comment@main

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -1,0 +1,53 @@
+# This workflow will install dependencies, create coverage tests and run Pytest Coverage Comment
+# For more information see: https://github.com/MishaKav/pytest-coverage-comment/
+name: pytest-coverage-comment
+on:
+  pull_request:
+    branches:
+      - '*'
+
+# https://docs.github.com/en/actions/using-jobs/assigning-permissions-to-jobs
+# `contents` is for permission to the contents of the repository.
+# `pull-requests` is for permission to pull request
+permissions:
+  contents: write
+  checks: write
+  pull-requests: write
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: Set up Python 3.10
+        uses: actions/setup-python@v2
+        with:
+          python-version: 3.10
+
+      - name: Install package
+        run: |
+            python -m pip install -e .[tests]
+            python -m pip freeze
+
+      - name: Build coverage file
+        run: |
+          pytest --junitxml=pytest.xml --cov-report=term-missing:skip-covered --cov=app tests/ | tee pytest-coverage.txt
+
+      - name: Pytest coverage comment
+        uses: MishaKav/pytest-coverage-comment@main
+        with:
+          pytest-coverage-path: ./pytest-coverage.txt
+          junitxml-path: ./pytest.xml
+
+      - name: Update Readme with Coverage Html
+        if: ${{ github.ref == 'refs/heads/main' }}
+        run: |
+          sed -i '/<!-- Pytest Coverage Comment:Begin -->/,/<!-- Pytest Coverage Comment:End -->/c\<!-- Pytest Coverage Comment:Begin -->\n\${{ steps.coverageComment.outputs.coverageHtml }}\n<!-- Pytest Coverage Comment:End -->' ./README.md
+
+      - name: Commit & Push changes to Readme
+        if: ${{ github.ref == 'refs/heads/main' }}
+        uses: actions-js/push@master
+        with:
+          message: Update coverage on Readme
+          github_token: ${{ secrets.GITHUB_TOKEN }}

--- a/data2rdf/models/base.py
+++ b/data2rdf/models/base.py
@@ -87,6 +87,16 @@ class BasicSuffixModel(BaseConfigModel):
         validate_default=True,
     )
 
+    @field_validator("iri")
+    @classmethod
+    def validate_iri(cls, value: Union[str, AnyUrl]) -> AnyUrl:
+        """Make sure that there are not blank spaces in the IRI"""
+        if isinstance(value, str):
+            value = AnyUrl(value.strip())
+        else:
+            value = AnyUrl(str(value).strip())
+        return value
+
     @field_validator("suffix")
     @classmethod
     def validate_suffix(

--- a/data2rdf/models/graph.py
+++ b/data2rdf/models/graph.py
@@ -225,7 +225,7 @@ class PropertyGraph(BasicGraphModel, BasicSuffixModel):
     value: Optional[str] = Field(
         None, description="Non-quantitative Value of the property"
     )
-    annotation: Optional[AnyUrl] = Field(
+    annotation: Optional[Union[str, AnyUrl]] = Field(
         None, description="Base IRI with which the value shall be concatenated"
     )
     value_relation: Optional[Union[str, AnyUrl]] = Field(
@@ -233,6 +233,14 @@ class PropertyGraph(BasicGraphModel, BasicSuffixModel):
         description="""Data or annotation property
         for mapping the data value to the individual.""",
     )
+
+    @field_validator("annotation")
+    @classmethod
+    def validate_annotation(cls, value: AnyUrl) -> AnyUrl:
+        """Make sure that there are not blank spaces in the IRI"""
+        if value:
+            value = AnyUrl(str(value).strip())
+        return value
 
     @model_validator(mode="after")
     @classmethod

--- a/docs/examples/abox/6_custom_relations.md
+++ b/docs/examples/abox/6_custom_relations.md
@@ -136,11 +136,13 @@ When the pipeline run is succeded, you see the following output by running `prin
 @prefix ns1: <https://w3id.org/emmo/domain/characterisation-methodology/chameo#> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
 
-<https://w3id.org/emmo/domain/domain-nanoindentation/nanoindentation#CSM1> rdfs:label "Continuous Stiffness Measurement" ;
+<https://w3id.org/emmo/domain/domain-nanoindentation/nanoindentation#CSM1> a <https://w3id.org/emmo/domain/domain-nanoindentation/nanoindentation#EMMO_5ca6e1c1-93e9-5e1a-881b-2c2bd38074b1> ;
+    rdfs:label "Continuous Stiffness Measurement" ;
     ns1:hasOperator <https://w3id.org/emmo/domain/domain-nanoindentation/nanoindentation#Operator1> .
 
 <https://w3id.org/emmo/domain/domain-nanoindentation/nanoindentation#Operator1> a ns1:Operator ;
     foaf:name "Jane Doe" .
+
 ```
 
 Again, you will be able to investigate the `general_metadata` and `plain_metadata` in the same way as stated in the [first example](1_csv). But this does take place for the `time_series_metadata` and `time_series` attributes, since we do not include any time series in this example here.

--- a/examples/6_graph_custom_relations.ipynb
+++ b/examples/6_graph_custom_relations.ipynb
@@ -23,7 +23,7 @@
     },
     {
       "cell_type": "code",
-      "execution_count": 13,
+      "execution_count": 1,
       "metadata": {},
       "outputs": [],
       "source": [
@@ -39,7 +39,7 @@
     },
     {
       "cell_type": "code",
-      "execution_count": 14,
+      "execution_count": 2,
       "metadata": {},
       "outputs": [
         {
@@ -70,7 +70,7 @@
     },
     {
       "cell_type": "code",
-      "execution_count": 15,
+      "execution_count": 3,
       "metadata": {},
       "outputs": [],
       "source": [
@@ -98,7 +98,7 @@
     },
     {
       "cell_type": "code",
-      "execution_count": 16,
+      "execution_count": 4,
       "metadata": {},
       "outputs": [],
       "source": [
@@ -119,7 +119,7 @@
     },
     {
       "cell_type": "code",
-      "execution_count": 17,
+      "execution_count": 5,
       "metadata": {},
       "outputs": [],
       "source": [
@@ -146,7 +146,7 @@
     },
     {
       "cell_type": "code",
-      "execution_count": 18,
+      "execution_count": 6,
       "metadata": {},
       "outputs": [
         {
@@ -157,7 +157,8 @@
             "@prefix ns1: <https://w3id.org/emmo/domain/characterisation-methodology/chameo#> .\n",
             "@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .\n",
             "\n",
-            "<https://w3id.org/emmo/domain/domain-nanoindentation/nanoindentation#CSM1> rdfs:label \"Continuous Stiffness Measurement\" ;\n",
+            "<https://w3id.org/emmo/domain/domain-nanoindentation/nanoindentation#CSM1> a <https://w3id.org/emmo/domain/domain-nanoindentation/nanoindentation#EMMO_5ca6e1c1-93e9-5e1a-881b-2c2bd38074b1> ;\n",
+            "    rdfs:label \"Continuous Stiffness Measurement\" ;\n",
             "    ns1:hasOperator <https://w3id.org/emmo/domain/domain-nanoindentation/nanoindentation#Operator1> .\n",
             "\n",
             "<https://w3id.org/emmo/domain/domain-nanoindentation/nanoindentation#Operator1> a ns1:Operator ;\n",
@@ -188,7 +189,7 @@
       "name": "python",
       "nbconvert_exporter": "python",
       "pygments_lexer": "ipython3",
-      "version": "3.12.2"
+      "version": "3.10.14"
     }
   },
   "nbformat": 4,

--- a/setup.cfg
+++ b/setup.cfg
@@ -52,6 +52,7 @@ pre_commit =
     pre-commit==2.15.0
 tests =
     pytest==8.2.2
+    pytest-cov==5.0.0
 
 [options.package_data]
 * = *.csv

--- a/tests/abox/dict_custom_properties/test_pipeline.py
+++ b/tests/abox/dict_custom_properties/test_pipeline.py
@@ -8,7 +8,7 @@ def test_pipeline_dict_custom_properties() -> None:
 
     data = {
         "data": {
-            "name": "G. Konstantopoulos",
+            "name": "Jane Doe",
             "measurement": "Continuous Stiffness Measurement",
         }
     }
@@ -22,7 +22,7 @@ def test_pipeline_dict_custom_properties() -> None:
         },
         {
             "value_location": "data.measurement",
-            "iri": "https://w3id.org/emmo/domain/domain-nanoindentation/nanoindentation#EMMO_5ca6e1c1-93e9-5e1a-881b-2c2bd38074b1 ",
+            "iri": "https://w3id.org/emmo/domain/domain-nanoindentation/nanoindentation#EMMO_5ca6e1c1-93e9-5e1a-881b-2c2bd38074b1",
             "suffix": "CSM1",
         },
     ]
@@ -42,12 +42,14 @@ def test_pipeline_dict_custom_properties() -> None:
     @prefix foaf: <http://xmlns.com/foaf/0.1/> .
     @prefix ns1: <https://w3id.org/emmo/domain/characterisation-methodology/chameo#> .
     @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+    @prefix ns2: <https://w3id.org/emmo/domain/domain-nanoindentation/nanoindentation#> .
 
-    <https://w3id.org/emmo/domain/domain-nanoindentation/nanoindentation#CSM1> rdfs:label "Continuous Stiffness Measurement" ;
-        ns1:hasOperator <https://w3id.org/emmo/domain/domain-nanoindentation/nanoindentation#Operator1> .
+    ns2:CSM1 a ns2:EMMO_5ca6e1c1-93e9-5e1a-881b-2c2bd38074b1 ;
+             rdfs:label "Continuous Stiffness Measurement" ;
+             ns1:hasOperator ns2:Operator1 .
 
-    <https://w3id.org/emmo/domain/domain-nanoindentation/nanoindentation#Operator1> a ns1:Operator ;
-        foaf:name "G. Konstantopoulos" .
+    ns2:Operator1 a ns1:Operator ;
+                  foaf:name "Jane Doe" .
     """
 
     pipeline = Data2RDF(

--- a/tests/abox/test_models.py
+++ b/tests/abox/test_models.py
@@ -60,3 +60,26 @@ def test_valued_quantity(unit):
     )
 
     assert model.graph.isomorphic(expected_graph)
+
+
+def test_bad_with_blank_space():
+    from rdflib import Graph
+
+    from data2rdf import QuantityGraph
+
+    expected = """@prefix fileid: <https://www.example.org/> .
+    @prefix qudt: <http://qudt.org/schema/qudt/> .
+    @prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+
+    fileid:test a <https://example.org/test> ;
+        qudt:hasUnit "http://qudt.org/vocab/unit/MilliM"^^xsd:anyURI ;
+        qudt:value "0.1"^^xsd:float .
+    """
+    expected_graph = Graph()
+    expected_graph.parse(format="turtle", data=expected)
+
+    model = QuantityGraph(
+        value=0.1, key="test", unit="mm", iri="https://example.org/test     "
+    )
+
+    assert model.graph.isomorphic(expected_graph)


### PR DESCRIPTION
Previously, the class of the individual cannot be properly recognized by rdflib, when a blank space is appended occuring in the IRI. 

Now, a validator is implemented stripping this blank spaces from the string, if they occur.