### PR TITLE
Fix/explicit datatypes abox

### DIFF
--- a/data2rdf/models/graph.py
+++ b/data2rdf/models/graph.py
@@ -3,7 +3,17 @@
 import warnings
 from typing import Any, Dict, List, Optional, Union
 
-from pydantic import (
+from data2rdf.models.utils import apply_datatype, detect_datatype
+from data2rdf.qudt.utils import _get_query_match
+from data2rdf.utils import make_prefix
+
+from data2rdf.models.base import (  # isort:skip
+    BasicGraphModel,
+    BasicSuffixModel,
+    RelationType,
+)
+
+from pydantic import (  # isort:skip
     AnyUrl,
     BaseModel,
     Field,
@@ -11,10 +21,6 @@ from pydantic import (
     field_validator,
     model_validator,
 )
-
-from data2rdf.models.base import BasicGraphModel, BasicSuffixModel
-from data2rdf.qudt.utils import _get_query_match
-from data2rdf.utils import is_bool, is_float, is_integer, is_uri, make_prefix
 
 
 class ValueRelationMapping(BaseModel):
@@ -55,65 +61,22 @@ class ClassTypeGraph(BasicGraphModel):
         None, description="Mappings for Data Properties"
     )
 
-    @classmethod
-    def detect_datatype(cls, value) -> "Dict[str, Any]":
-        """Return json with value definition"""
-        if is_integer(value):
-            dtype = "xsd:integer"
-            value = int(value)
-        elif is_float(value):
-            dtype = "xsd:float"
-            value = float(value)
-        elif is_bool(value):
-            dtype = "xsd:bool"
-            value = bool(value)
-        elif is_uri(value):
-            dtype = "xsd:anyURI"
-            value = str(value)
-        elif isinstance(value, str):
-            dtype = "xsd:string"
-        else:
-            raise TypeError(
-                f"Datatype of value `{value}` ({type(value)}) cannot be mapped to xsd."
-            )
-
-        return {"@type": dtype, "@value": value}
-
-    def apply_datatype(self, model: ValueRelationMapping) -> "Dict[str, Any]":
-        if model.datatype == "integer":
-            value = int(model.value)
-        elif model.datatype == "float":
-            value = float(model.value)
-        elif model.datatype == "bool":
-            value = bool(model.value)
-        elif model.datatype == "anyURI":
-            value = str(model.value)
-        elif model.datatype == "string":
-            value = str(model.value)
-        else:
-            raise TypeError(
-                f"""Datatype of value `{model.value}` ({model.datatype}) currently not supported.
-                Supported datatypes: integer, float, bool, anyURI, string"""
-            )
-
-        return {"@type": f"xsd:{model.datatype}", "@value": value}
-
     # OVERRIDE
     @property
     def json_ld(self) -> "Dict[str, Any]":
         annotations = {
             model.relation: (
-                self.apply_datatype(model)
+                apply_datatype(model)
                 if model.datatype
-                else self.detect_datatype(model.value)
+                else detect_datatype(str(model.value))
             )
             for model in self.annotation_properties
         }
         datatypes = {
             model.relation: (
-                self.apply_datatype(model)
+                apply_datatype(model.value, model.datatype)
                 if model.datatype
-                else self.detect_datatype(model.value)
+                else detect_datatype(str(model.value))
             )
             for model in self.data_properties
         }
@@ -198,7 +161,11 @@ class QuantityGraph(BasicGraphModel, BasicSuffixModel):
                 "qudt": "http://qudt.org/schema/qudt/",
             },
             "@id": f"{cls.config.prefix_name}:{cls.suffix}",
-            "@type": str(cls.iri),
+            "@type": (
+                [str(iri) for iri in cls.iri]
+                if isinstance(cls.iri, list)
+                else str(cls.iri)
+            ),
             **cls.unit_json,
             **cls.value_json,
         }
@@ -221,25 +188,7 @@ class QuantityGraph(BasicGraphModel, BasicSuffixModel):
     def value_json(self) -> "Dict[str, Any]":
         """Return json with value definition"""
         if self.value:
-            if is_float(self.value):
-                dtype = "xsd:float"
-                value = float(self.value)
-            elif is_integer(self.value):
-                dtype = "xsd:integer"
-                value = int(self.value)
-            elif is_bool(self.value):
-                dtype = "xsd:bool"
-                value = bool(self.value)
-            elif is_uri(self.value):
-                dtype = "xsd:anyURI"
-                value = str(self.value)
-            else:
-                raise ValueError(
-                    f"""Datatype not recognized for key
-                    `{self.key}` with value:
-                    `{self.value}`"""
-                )
-            value = {self.value_relation: {"@type": dtype, "@value": value}}
+            value = {self.value_relation: detect_datatype(str(self.value))}
         else:
             value = {}
         return value
@@ -262,8 +211,12 @@ class PropertyGraph(BasicGraphModel, BasicSuffixModel):
         description="""Data or annotation property
         for mapping the data value to the individual.""",
     )
-    datatype: Optional[str] = Field(
-        None, description="XSD Datatype of the value"
+    value_relation_type: Optional[RelationType] = Field(
+        None, description="Type of the semantic relation used in the mappings"
+    )
+    value_datatype: Optional[str] = Field(
+        None,
+        description="In case of an annotation or data property, this field indicates the XSD Datatype of the value",
     )
 
     @field_validator("annotation")
@@ -304,43 +257,14 @@ class PropertyGraph(BasicGraphModel, BasicSuffixModel):
     @property
     def value_json(self) -> "Optional[Dict[str, str]]":
         if not isinstance(self.value, type(None)):
-            if not self.datatype:
-                if is_integer(self.value):
-                    dtype = "xsd:integer"
-                    value = int(self.value)
-                elif is_float(self.value):
-                    dtype = "xsd:float"
-                    value = float(self.value)
-                elif is_bool(self.value):
-                    dtype = "xsd:bool"
-                    value = bool(self.value)
-                elif is_uri(self.value):
-                    dtype = "xsd:anyURI"
-                    value = str(self.value)
+            if self.value_relation_type != RelationType.OBJECT_PROPERTY:
+                if not self.value_datatype:
+                    spec = detect_datatype(str(self.value))
                 else:
-                    value = str(self.value)
-                    dtype = "xsd:string"
+                    spec = apply_datatype(self.value, self.value_datatype)
+                response = {self.value_relation: spec}
             else:
-                dtype = f"xsd:{self.datatype}"
-                if dtype == "xsd:anyURI":
-                    value = str(self.value)
-                elif dtype == "xsd:bool":
-                    value = bool(self.value)
-                elif dtype == "xsd:integer":
-                    value = int(self.value)
-                elif dtype == "xsd:float":
-                    value = float(self.value)
-                elif dtype == "xsd:string":
-                    value = str(self.value)
-                else:
-                    raise ValueError(
-                        f"""Datatype not recognized for concept with iri
-                        `{self.iri}` and value:
-                        `{self.value}`"""
-                    )
-
-            response = {self.value_relation: {"@type": dtype, "@value": value}}
-
+                response = {self.value_relation: {"@id": str(self.value)}}
         else:
             response = {}
         return response
@@ -351,10 +275,22 @@ class PropertyGraph(BasicGraphModel, BasicSuffixModel):
         if cls.annotation:
             types = {
                 "@type": [
-                    str(cls.iri),
+                    (
+                        [str(iri) for iri in cls.iri]
+                        if isinstance(cls.iri, list)
+                        else str(cls.iri)
+                    ),
                     cls.annotation,
                 ]
             }
         else:
-            types = {"@type": str(cls.iri)}
+            types = {
+                "@type": [
+                    (
+                        [str(iri) for iri in cls.iri]
+                        if isinstance(cls.iri, list)
+                        else str(cls.iri)
+                    )
+                ]
+            }
         return types

--- a/data2rdf/models/mapping.py
+++ b/data2rdf/models/mapping.py
@@ -35,6 +35,10 @@ class TBoxBaseMapping(BasicConceptMapping):
         ..., description="Type of the semantic relation used in the mappings"
     )
 
+    datatype: Optional[str] = Field(
+        None, description="XSD Datatype of the targed value"
+    )
+
 
 class CustomRelation(BaseModel):
     """Custom relation model"""

--- a/data2rdf/models/mapping.py
+++ b/data2rdf/models/mapping.py
@@ -1,19 +1,11 @@
 """Mapping models for data2rdf"""
 
-from enum import Enum
+
 from typing import List, Optional, Union
 
 from pydantic import AnyUrl, BaseModel, Field, field_validator, model_validator
 
-from .base import BasicConceptMapping, BasicSuffixModel
-
-
-class RelationType(str, Enum):
-    """Relation Type of TBox modellings"""
-
-    ANNOTATION_PROPERTY = "annotation_property"
-    DATA_PROPERTY = "data_property"
-    OBJECT_PROPERTY = "object_property"
+from .base import BasicConceptMapping, BasicSuffixModel, RelationType
 
 
 class TBoxBaseMapping(BasicConceptMapping):
@@ -55,6 +47,9 @@ class CustomRelation(BaseModel):
     object_data_type: Optional[str] = Field(
         None, description="XSD Data type of the object"
     )
+    relation_type: Optional[RelationType] = Field(
+        None, description="Type of the semantic relation used in the mappings"
+    )
 
 
 class ABoxBaseMapping(BasicConceptMapping, BasicSuffixModel):
@@ -93,7 +88,12 @@ class ABoxBaseMapping(BasicConceptMapping, BasicSuffixModel):
         description="""Data or annotation property
         for mapping the data value to the individual.""",
     )
-
+    value_relation_type: Optional[RelationType] = Field(
+        None, description="Type of the semantic relation used in the mappings"
+    )
+    value_datatype: Optional[str] = Field(
+        None, description="XSD Datatype of the targed value"
+    )
     unit_relation: Optional[Union[str, AnyUrl]] = Field(
         None,
         description="""Object property for mapping the IRI

--- a/data2rdf/models/utils.py
+++ b/data2rdf/models/utils.py
@@ -1,0 +1,104 @@
+"""Data2RDF model utilities"""
+
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from typing import Any, Dict
+
+
+
+import ast
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from data2rdf.config import Config
+
+
+def is_integer(s):
+    try:
+        int(s)
+        return True
+    except ValueError:
+        return False
+
+
+def is_float(s):
+    try:
+        float(s)
+        return True
+    except ValueError:
+        return False
+
+
+def is_bool(s):
+    try:
+        ast.literal_eval(s)
+        return True
+    except Exception:
+        return False
+
+
+def is_uri(s):
+    try:
+        if str(s).startswith("http://") or str(s).startswith("https://"):
+            return True
+    except Exception:
+        return False
+
+def detect_datatype(value) -> "Dict[str, Any]":
+    """Return json with value definition"""
+    if is_integer(value):
+        dtype = "xsd:integer"
+        value = int(value)
+    elif is_float(value):
+        dtype = "xsd:float"
+        value = float(value)
+    elif is_bool(value):
+        dtype = "xsd:bool"
+        value = bool(value)
+    elif is_uri(value):
+        dtype = "xsd:anyURI"
+        value = str(value)
+    elif isinstance(value, str):
+        dtype = "xsd:string"
+    else:
+        raise TypeError(
+            f"Datatype of value `{value}` ({type(value)}) cannot be mapped to xsd."
+        )
+
+    return {"@type": dtype, "@value": value}
+
+def apply_datatype(value: "Any", datatype: str) -> "Dict[str, Any]":
+    """
+    Converts the input value to the specified datatype and returns a dictionary 
+    with the datatype and the converted value.
+
+    Args:
+        value (Any): The value to be converted.
+        datatype (str): The target datatype as a string. Supported datatypes 
+                        are "integer", "float", "bool", "anyURI", and "string".
+
+    Returns:
+        Dict[str, Any]: A dictionary containing the datatype under the "@type" key 
+                        and the converted value under the "@value" key.
+
+    Raises:
+        TypeError: If the provided datatype is not supported.
+    """
+    if datatype == "integer":
+        value = int(value)
+    elif datatype == "float":
+        value = float(value)
+    elif datatype == "bool":
+        value = bool(value)
+    elif datatype == "anyURI":
+        value = str(value)
+    elif datatype == "string":
+        value = str(value)
+    else:
+        raise TypeError(
+            f"""Datatype of value `{value}` ({datatype}) currently not supported.
+            Supported datatypes: integer, float, bool, anyURI, string"""
+        )
+
+    return {"@type": f"xsd:{datatype}", "@value": value}

--- a/data2rdf/models/utils.py
+++ b/data2rdf/models/utils.py
@@ -6,12 +6,7 @@ if TYPE_CHECKING:
     from typing import Any, Dict
 
 
-
 import ast
-from typing import TYPE_CHECKING
-
-if TYPE_CHECKING:
-    from data2rdf.config import Config
 
 
 def is_integer(s):
@@ -45,6 +40,7 @@ def is_uri(s):
     except Exception:
         return False
 
+
 def detect_datatype(value) -> "Dict[str, Any]":
     """Return json with value definition"""
     if is_integer(value):
@@ -68,18 +64,19 @@ def detect_datatype(value) -> "Dict[str, Any]":
 
     return {"@type": dtype, "@value": value}
 
+
 def apply_datatype(value: "Any", datatype: str) -> "Dict[str, Any]":
     """
-    Converts the input value to the specified datatype and returns a dictionary 
+    Converts the input value to the specified datatype and returns a dictionary
     with the datatype and the converted value.
 
     Args:
         value (Any): The value to be converted.
-        datatype (str): The target datatype as a string. Supported datatypes 
+        datatype (str): The target datatype as a string. Supported datatypes
                         are "integer", "float", "bool", "anyURI", and "string".
 
     Returns:
-        Dict[str, Any]: A dictionary containing the datatype under the "@type" key 
+        Dict[str, Any]: A dictionary containing the datatype under the "@type" key
                         and the converted value under the "@value" key.
 
     Raises:

--- a/data2rdf/parsers/base.py
+++ b/data2rdf/parsers/base.py
@@ -132,12 +132,14 @@ class TBoxBaseParser(AnyBoxBaseParser):
         where the suffix of the ontological class to be created.""",
     )
 
-    rdfs_type: AnyUrl = Field(
-        "owl:Class", description="rdfs:type for the concepts"
+    rdfs_type_location: Optional[str] = Field(
+        None,
+        description="""Key/column name/reference to location in the data file
+        where the rdfs:type for the concepts is defined.""",
     )
 
     version_info: Optional[str] = Field(
-        None, description="Version of the ontplpgy"
+        None, description="Version of the ontology"
     )
 
     ontology_iri: Optional[Union[str, AnyUrl]] = Field(
@@ -150,6 +152,10 @@ class TBoxBaseParser(AnyBoxBaseParser):
 
     authors: Optional[List[str]] = Field(
         None, description="Name of the authors contributing to the ontology."
+    )
+
+    fillna: Optional[Any] = Field(
+        "", description="Value to fill NaN values in the parsed dataframe."
     )
 
     _classes: Any = PrivateAttr()

--- a/data2rdf/parsers/excel.py
+++ b/data2rdf/parsers/excel.py
@@ -404,7 +404,11 @@ class ExcelABoxParser(ABoxBaseParser):
                             model_data["unit_relation"] = datum.unit_relation
                         model = QuantityGraph(**model_data)
                     else:
-                        model = PropertyGraph(**model_data)
+                        model = PropertyGraph(
+                            **model_data,
+                            value_datatype=datum.value_datatype,
+                            value_relation_type=datum.value_relation_type,
+                        )
 
                     if model_data.get("value"):
                         self._general_metadata.append(model)
@@ -425,10 +429,11 @@ class ExcelABoxParser(ABoxBaseParser):
                     if value:
                         model = PropertyGraph(
                             value_relation=relation.relation,
+                            value_relation_type=relation.relation_type,
+                            value_datatype=relation.object_data_type,
                             value=value,
                             iri=datum.iri,
                             suffix=suffix,
-                            datatype=relation.object_data_type,
                             config=self.config,
                         )
                         self._general_metadata.append(model)

--- a/data2rdf/parsers/excel.py
+++ b/data2rdf/parsers/excel.py
@@ -2,7 +2,7 @@
 
 import warnings
 from io import BytesIO
-from typing import Any, Dict, List, Optional, Union
+from typing import Any, Dict, List, Union
 from urllib.parse import quote, urljoin
 
 import pandas as pd
@@ -54,10 +54,6 @@ class ExcelTBoxParser(TBoxBaseParser):
         ...,
         description="""File path to the mapping file to be parsed or
         a list with the mapping.""",
-    )
-
-    fillna: Optional[Any] = Field(
-        "", description="Value to fill NaN values in the parsed dataframe."
     )
 
     # OVERRIDE

--- a/data2rdf/parsers/json.py
+++ b/data2rdf/parsers/json.py
@@ -410,6 +410,7 @@ class JsonABoxParser(ABoxBaseParser):
                             model = PropertyGraph(
                                 value=val,
                                 value_relation_type=datum.value_relation_type,
+                                value_datatype=datum.value_datatype,
                                 **model_data,
                             )
                             self._general_metadata.append(model)
@@ -430,6 +431,7 @@ class JsonABoxParser(ABoxBaseParser):
                     elif isinstance(value, NUMERICALS) and not unit:
                         model = PropertyGraph(
                             value_relation_type=datum.value_relation_type,
+                            value_datatype=datum.value_datatype,
                             value=value,
                             **model_data,
                         )

--- a/data2rdf/utils.py
+++ b/data2rdf/utils.py
@@ -1,42 +1,9 @@
 """General data2rdf utils"""
 
-import ast
 from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
     from data2rdf.config import Config
-
-
-def is_integer(s):
-    try:
-        int(s)
-        return True
-    except ValueError:
-        return False
-
-
-def is_float(s):
-    try:
-        float(s)
-        return True
-    except ValueError:
-        return False
-
-
-def is_bool(s):
-    try:
-        ast.literal_eval(s)
-        return True
-    except Exception:
-        return False
-
-
-def is_uri(s):
-    try:
-        if str(s).startswith("http://") or str(s).startswith("https://"):
-            return True
-    except Exception:
-        return False
 
 
 def make_prefix(config: "Config") -> str:

--- a/tests/abox/csv_pipeline_test/output/output_csv_parser.ttl
+++ b/tests/abox/csv_pipeline_test/output/output_csv_parser.ttl
@@ -159,15 +159,15 @@ fileid:Material a <https://w3id.org/steel/ProcessOntology/Material>,
 
 fileid:OriginalGaugeLength a <https://w3id.org/steel/ProcessOntology/OriginalGaugeLength> ;
     qudt:hasUnit "http://qudt.org/vocab/unit/MilliM"^^xsd:anyURI ;
-    qudt:value "80.0"^^xsd:float .
+    qudt:value "80"^^xsd:integer .
 
 fileid:ParallelLength a <https://w3id.org/steel/ProcessOntology/ParallelLength> ;
     qudt:hasUnit "http://qudt.org/vocab/unit/MilliM"^^xsd:anyURI ;
-    qudt:value "120.0"^^xsd:float .
+    qudt:value "120"^^xsd:integer .
 
 fileid:Preload a <https://w3id.org/steel/ProcessOntology/Preload> ;
     qudt:hasUnit "http://qudt.org/vocab/unit/MegaPA"^^xsd:anyURI ;
-    qudt:value "2.0"^^xsd:float .
+    qudt:value "2"^^xsd:integer .
 
 fileid:ProjectName a <https://w3id.org/steel/ProcessOntology/ProjectName> ;
     rdfs:label "proj_name_1"^^xsd:string .
@@ -197,7 +197,7 @@ fileid:StandardForce a <https://w3id.org/steel/ProcessOntology/StandardForce> ;
 
 fileid:Temperature a <https://w3id.org/steel/ProcessOntology/Temperature> ;
     qudt:hasUnit "http://qudt.org/vocab/unit/DEG_C"^^xsd:anyURI ;
-    qudt:value "22.0"^^xsd:float .
+    qudt:value "22"^^xsd:integer .
 
 fileid:TestStandard a <https://w3id.org/steel/ProcessOntology/TestStandard> ;
     rdfs:label "ISO-XX"^^xsd:string .

--- a/tests/abox/csv_pipeline_test/output/output_pipeline.ttl
+++ b/tests/abox/csv_pipeline_test/output/output_pipeline.ttl
@@ -64,7 +64,7 @@ fileid:SamplePreparatation a ns1:Activity ;
 fileid:Temperature a ns1:Entity,
         <https://w3id.org/steel/ProcessOntology/Temperature> ;
     qudt:hasUnit "http://qudt.org/vocab/unit/DEG_C"^^xsd:anyURI ;
-    qudt:value "22.0"^^xsd:float ;
+    qudt:value "22"^^xsd:integer ;
     ns1:wasAttributedTo fileid:TestingLab .
 
 fileid:TestTime a <https://w3id.org/steel/ProcessOntology/TestTime> ;
@@ -227,19 +227,19 @@ fileid:Material a ns1:Agent,
 fileid:OriginalGaugeLength a ns1:Entity,
         <https://w3id.org/steel/ProcessOntology/OriginalGaugeLength> ;
     qudt:hasUnit "http://qudt.org/vocab/unit/MilliM"^^xsd:anyURI ;
-    qudt:value "80.0"^^xsd:float ;
+    qudt:value "80"^^xsd:integer ;
     ns1:wasAttributedTo fileid:DisplacementTransducer .
 
 fileid:ParallelLength a ns1:Entity,
         <https://w3id.org/steel/ProcessOntology/ParallelLength> ;
     qudt:hasUnit "http://qudt.org/vocab/unit/MilliM"^^xsd:anyURI ;
-    qudt:value "120.0"^^xsd:float ;
+    qudt:value "120"^^xsd:integer ;
     ns1:wasAttributedTo fileid:TensileTestSpecimen .
 
 fileid:Preload a ns1:Entity,
         <https://w3id.org/steel/ProcessOntology/Preload> ;
     qudt:hasUnit "http://qudt.org/vocab/unit/MegaPA"^^xsd:anyURI ;
-    qudt:value "2.0"^^xsd:float ;
+    qudt:value "2"^^xsd:integer ;
     ns1:wasAttributedTo fileid:TensileTestingMachine .
 
 fileid:ProjectName a ns1:Entity,

--- a/tests/abox/json_multiple_iris/test_multiple_iris.py
+++ b/tests/abox/json_multiple_iris/test_multiple_iris.py
@@ -1,0 +1,154 @@
+"""Test abox with multiple IRIs"""
+
+DATA = {
+         "Identifier":"123",
+         "Material":[
+            "https://example.materials-data.space/knowledge/material/material1",
+            "https://example.materials-data.space/knowledge/material/material2"
+         ]
+      }
+
+
+MAPPING = [
+    {
+        "iri": [
+            "https://w3id.org/emmo#EMMO_ee0466e4_780d_4236_8281_ace7ad3fc5d2",
+            "https://example.org/0034d610-959d-4dd0-97f0-f3b36eeea5c4"
+            ],
+        "suffix":"Identifier",
+        "value_location":"Identifier",
+        "value_relation":"https://w3id.org/emmo#EMMO_a592c856_4103_43cf_8635_1982a1e5d5de",
+        "datatype": "integer"
+    },
+    {
+        "iri": [
+            "https://w3id.org/emmo#Material",
+            "https://example.org/0034d610-959d-4dd0-97f0-f3b36eeea5c4"
+            ],
+        "suffix": "Material",
+        "value_location":"Material",
+        "value_relation":"http://www.w3.org/2000/01/rdf-schema#relatedTo",
+        "value_relation_type":"object_property"
+    }
+]
+
+EXPECTED = """
+@prefix ns1: <https://w3id.org/emmo#> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+
+<https://example.materials-data.space/knowledge/testing-machine/Identifier> a <https://example.org/0034d610-959d-4dd0-97f0-f3b36eeea5c4>,
+        ns1:EMMO_ee0466e4_780d_4236_8281_ace7ad3fc5d2 ;
+    ns1:EMMO_a592c856_4103_43cf_8635_1982a1e5d5de 123 .
+
+<https://example.materials-data.space/knowledge/testing-machine/Material> a <https://example.org/0034d610-959d-4dd0-97f0-f3b36eeea5c4>,
+        ns1:Material ;
+    rdfs:relatedTo <https://example.materials-data.space/knowledge/material/material1>,
+        <https://example.materials-data.space/knowledge/material/material2> .
+
+"""
+
+DATA_CUMSTOM_RELATIONS ={
+   "testing-machine":[
+      {
+         "Description":"Some description",
+         "Identifier":"123",
+         "Material":[
+            "https://example.materials-data.space/knowledge/material/material1",
+            "https://example.materials-data.space/knowledge/material/material2"
+         ],
+         "id":"0034d610-959d-4dd0-97f0-f3b36eeea5c4",
+         "slug":"testing-machine1",
+         "Name":"Testing machine1"
+      }
+   ]
+}
+
+MAPPING_CUSTOM_RELATIONS = [
+    {
+        "iri": [
+            "https://w3id.org/emmo#EMMO_ee0466e4_780d_4236_8281_ace7ad3fc5d2",
+            "https://example.org/0034d610-959d-4dd0-97f0-f3b36eeea5c4"
+            ],
+        "suffix":"slug",
+        "source":"testing-machine[*]",
+        "suffix_from_location":True,
+        "custom_relations":[
+            {
+                "object_location":"Description",
+                "relation":"http://www.w3.org/2000/01/rdf-schema#comment",
+                "relation_type":"data_property"
+            },
+            {
+                "object_location":"Identifier",
+                "relation":"https://w3id.org/emmo#EMMO_a592c856_4103_43cf_8635_1982a1e5d5de",
+                "relation_type":"data_property"
+            },
+            {
+                "object_location":"Material",
+                "relation":"http://www.w3.org/2000/01/rdf-schema#relatedTo",
+                "relation_type":"object_property"
+            },
+            {
+                "object_location":"Name",
+                "relation":"http://www.w3.org/2000/01/rdf-schema#label",
+                "relation_type":"annotation_property"
+            }
+        ]
+    }
+]
+
+EXPECTED_CUSTOM_RELATIONS = """
+@prefix ns1: <https://w3id.org/emmo#> .
+@prefix owl: <http://www.w3.org/2002/07/owl#> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+@prefix ex: <https://example.org/> .
+
+<https://example.materials-data.space/knowledge/testing-machine/testing-machine1> a ns1:EMMO_ee0466e4_780d_4236_8281_ace7ad3fc5d2 , ex:0034d610-959d-4dd0-97f0-f3b36eeea5c4 ;
+    rdfs:label "Testing machine1"^^xsd:string ;
+    rdfs:comment "Some description"^^xsd:string ;
+    rdfs:relatedTo <https://example.materials-data.space/knowledge/material/material1> ,
+                   <https://example.materials-data.space/knowledge/material/material2> ;
+    ns1:EMMO_a592c856_4103_43cf_8635_1982a1e5d5de 123 .
+"""
+
+def test_multiple_iris_custom_relations():
+    
+    from data2rdf import Data2RDF, Parser
+    from rdflib import Graph
+
+    pipeline = Data2RDF(
+        raw_data=DATA_CUMSTOM_RELATIONS,
+        mapping=MAPPING_CUSTOM_RELATIONS,
+        parser=Parser.json,
+        parser_args={"expand_array":True},
+        config={
+            "base_iri":"https://example.materials-data.space/knowledge/testing-machine/",
+            "suppress_file_description":True
+        }
+    )
+    expected_graph = Graph()
+    expected_graph.parse(data=EXPECTED_CUSTOM_RELATIONS)
+
+    assert pipeline.graph.isomorphic(expected_graph)
+
+def test_multiple_iris():
+    
+    from data2rdf import Data2RDF, Parser
+    from rdflib import Graph
+
+    pipeline = Data2RDF(
+        raw_data=DATA,
+        mapping=MAPPING,
+        parser=Parser.json,
+        parser_args={"expand_array":True},
+        config={
+            "base_iri":"https://example.materials-data.space/knowledge/testing-machine/",
+            "suppress_file_description":True
+        }
+    )
+    expected_graph = Graph()
+    expected_graph.parse(data=EXPECTED)
+
+    assert pipeline.graph.isomorphic(expected_graph)

--- a/tests/abox/json_multiple_iris/test_multiple_iris.py
+++ b/tests/abox/json_multiple_iris/test_multiple_iris.py
@@ -1,35 +1,35 @@
 """Test abox with multiple IRIs"""
 
 DATA = {
-         "Identifier":"123",
-         "Material":[
-            "https://example.materials-data.space/knowledge/material/material1",
-            "https://example.materials-data.space/knowledge/material/material2"
-         ]
-      }
+    "Identifier": "123",
+    "Material": [
+        "https://example.materials-data.space/knowledge/material/material1",
+        "https://example.materials-data.space/knowledge/material/material2",
+    ],
+}
 
 
 MAPPING = [
     {
         "iri": [
             "https://w3id.org/emmo#EMMO_ee0466e4_780d_4236_8281_ace7ad3fc5d2",
-            "https://example.org/0034d610-959d-4dd0-97f0-f3b36eeea5c4"
-            ],
-        "suffix":"Identifier",
-        "value_location":"Identifier",
-        "value_relation":"https://w3id.org/emmo#EMMO_a592c856_4103_43cf_8635_1982a1e5d5de",
-        "datatype": "integer"
+            "https://example.org/0034d610-959d-4dd0-97f0-f3b36eeea5c4",
+        ],
+        "suffix": "Identifier",
+        "value_location": "Identifier",
+        "value_relation": "https://w3id.org/emmo#EMMO_a592c856_4103_43cf_8635_1982a1e5d5de",
+        "datatype": "integer",
     },
     {
         "iri": [
             "https://w3id.org/emmo#Material",
-            "https://example.org/0034d610-959d-4dd0-97f0-f3b36eeea5c4"
-            ],
+            "https://example.org/0034d610-959d-4dd0-97f0-f3b36eeea5c4",
+        ],
         "suffix": "Material",
-        "value_location":"Material",
-        "value_relation":"http://www.w3.org/2000/01/rdf-schema#relatedTo",
-        "value_relation_type":"object_property"
-    }
+        "value_location": "Material",
+        "value_relation": "http://www.w3.org/2000/01/rdf-schema#relatedTo",
+        "value_relation_type": "object_property",
+    },
 ]
 
 EXPECTED = """
@@ -48,53 +48,53 @@ EXPECTED = """
 
 """
 
-DATA_CUMSTOM_RELATIONS ={
-   "testing-machine":[
-      {
-         "Description":"Some description",
-         "Identifier":"123",
-         "Material":[
-            "https://example.materials-data.space/knowledge/material/material1",
-            "https://example.materials-data.space/knowledge/material/material2"
-         ],
-         "id":"0034d610-959d-4dd0-97f0-f3b36eeea5c4",
-         "slug":"testing-machine1",
-         "Name":"Testing machine1"
-      }
-   ]
+DATA_CUMSTOM_RELATIONS = {
+    "testing-machine": [
+        {
+            "Description": "Some description",
+            "Identifier": "123",
+            "Material": [
+                "https://example.materials-data.space/knowledge/material/material1",
+                "https://example.materials-data.space/knowledge/material/material2",
+            ],
+            "id": "0034d610-959d-4dd0-97f0-f3b36eeea5c4",
+            "slug": "testing-machine1",
+            "Name": "Testing machine1",
+        }
+    ]
 }
 
 MAPPING_CUSTOM_RELATIONS = [
     {
         "iri": [
             "https://w3id.org/emmo#EMMO_ee0466e4_780d_4236_8281_ace7ad3fc5d2",
-            "https://example.org/0034d610-959d-4dd0-97f0-f3b36eeea5c4"
-            ],
-        "suffix":"slug",
-        "source":"testing-machine[*]",
-        "suffix_from_location":True,
-        "custom_relations":[
+            "https://example.org/0034d610-959d-4dd0-97f0-f3b36eeea5c4",
+        ],
+        "suffix": "slug",
+        "source": "testing-machine[*]",
+        "suffix_from_location": True,
+        "custom_relations": [
             {
-                "object_location":"Description",
-                "relation":"http://www.w3.org/2000/01/rdf-schema#comment",
-                "relation_type":"data_property"
+                "object_location": "Description",
+                "relation": "http://www.w3.org/2000/01/rdf-schema#comment",
+                "relation_type": "data_property",
             },
             {
-                "object_location":"Identifier",
-                "relation":"https://w3id.org/emmo#EMMO_a592c856_4103_43cf_8635_1982a1e5d5de",
-                "relation_type":"data_property"
+                "object_location": "Identifier",
+                "relation": "https://w3id.org/emmo#EMMO_a592c856_4103_43cf_8635_1982a1e5d5de",
+                "relation_type": "data_property",
             },
             {
-                "object_location":"Material",
-                "relation":"http://www.w3.org/2000/01/rdf-schema#relatedTo",
-                "relation_type":"object_property"
+                "object_location": "Material",
+                "relation": "http://www.w3.org/2000/01/rdf-schema#relatedTo",
+                "relation_type": "object_property",
             },
             {
-                "object_location":"Name",
-                "relation":"http://www.w3.org/2000/01/rdf-schema#label",
-                "relation_type":"annotation_property"
-            }
-        ]
+                "object_location": "Name",
+                "relation": "http://www.w3.org/2000/01/rdf-schema#label",
+                "relation_type": "annotation_property",
+            },
+        ],
     }
 ]
 
@@ -113,40 +113,42 @@ EXPECTED_CUSTOM_RELATIONS = """
     ns1:EMMO_a592c856_4103_43cf_8635_1982a1e5d5de 123 .
 """
 
+
 def test_multiple_iris_custom_relations():
-    
-    from data2rdf import Data2RDF, Parser
     from rdflib import Graph
+
+    from data2rdf import Data2RDF, Parser
 
     pipeline = Data2RDF(
         raw_data=DATA_CUMSTOM_RELATIONS,
         mapping=MAPPING_CUSTOM_RELATIONS,
         parser=Parser.json,
-        parser_args={"expand_array":True},
+        parser_args={"expand_array": True},
         config={
-            "base_iri":"https://example.materials-data.space/knowledge/testing-machine/",
-            "suppress_file_description":True
-        }
+            "base_iri": "https://example.materials-data.space/knowledge/testing-machine/",
+            "suppress_file_description": True,
+        },
     )
     expected_graph = Graph()
     expected_graph.parse(data=EXPECTED_CUSTOM_RELATIONS)
 
     assert pipeline.graph.isomorphic(expected_graph)
 
+
 def test_multiple_iris():
-    
-    from data2rdf import Data2RDF, Parser
     from rdflib import Graph
+
+    from data2rdf import Data2RDF, Parser
 
     pipeline = Data2RDF(
         raw_data=DATA,
         mapping=MAPPING,
         parser=Parser.json,
-        parser_args={"expand_array":True},
+        parser_args={"expand_array": True},
         config={
-            "base_iri":"https://example.materials-data.space/knowledge/testing-machine/",
-            "suppress_file_description":True
-        }
+            "base_iri": "https://example.materials-data.space/knowledge/testing-machine/",
+            "suppress_file_description": True,
+        },
     )
     expected_graph = Graph()
     expected_graph.parse(data=EXPECTED)

--- a/tests/abox/xls_pipeline_test/output/output_excel_parser.ttl
+++ b/tests/abox/xls_pipeline_test/output/output_excel_parser.ttl
@@ -106,7 +106,7 @@ fileid:Material a <https://w3id.org/steel/ProcessOntology/Material>,
 
 fileid:OriginalGaugeLength a <https://w3id.org/steel/ProcessOntology/OriginalGaugeLength> ;
     qudt:hasUnit "http://qudt.org/vocab/unit/MilliM"^^xsd:anyURI ;
-    qudt:value "15.0"^^xsd:float .
+    qudt:value "15"^^xsd:integer .
 
 fileid:PercentageElongation a <https://w3id.org/steel/ProcessOntology/PercentageElongation> ;
     qudt:hasUnit "http://qudt.org/vocab/unit/FRACTION"^^xsd:anyURI .
@@ -133,7 +133,7 @@ fileid:StandardForce a <https://w3id.org/steel/ProcessOntology/StandardForce> ;
 
 fileid:Temperature a <https://w3id.org/steel/ProcessOntology/Temperature> ;
     qudt:hasUnit "http://qudt.org/vocab/unit/DEG_C"^^xsd:anyURI ;
-    qudt:value "25.0"^^xsd:float .
+    qudt:value "25"^^xsd:integer .
 
 fileid:TestTime a <https://w3id.org/steel/ProcessOntology/TestTime> ;
     qudt:hasUnit "http://qudt.org/vocab/unit/SEC"^^xsd:anyURI .

--- a/tests/abox/xls_pipeline_test/output/output_pipeline.ttl
+++ b/tests/abox/xls_pipeline_test/output/output_pipeline.ttl
@@ -72,7 +72,7 @@ fileid:SamplePreparatation a ns1:Activity ;
 fileid:Temperature a ns1:Entity,
         <https://w3id.org/steel/ProcessOntology/Temperature> ;
     qudt:hasUnit "http://qudt.org/vocab/unit/DEG_C"^^xsd:anyURI ;
-    qudt:value "25.0"^^xsd:float ;
+    qudt:value "25"^^xsd:integer ;
     ns1:wasAttributedTo fileid:TestingLab .
 
 fileid:TestTime a <https://w3id.org/steel/ProcessOntology/TestTime> ;
@@ -191,7 +191,7 @@ fileid:Material a ns1:Agent,
 fileid:OriginalGaugeLength a ns1:Entity,
         <https://w3id.org/steel/ProcessOntology/OriginalGaugeLength> ;
     qudt:hasUnit "http://qudt.org/vocab/unit/MilliM"^^xsd:anyURI ;
-    qudt:value "15.0"^^xsd:float ;
+    qudt:value "15"^^xsd:integer ;
     ns1:wasAttributedTo fileid:DisplacementTransducer .
 
 fileid:ProjectNumber a ns1:Entity,

--- a/tests/abox/xls_pipeline_test/test_parser.py
+++ b/tests/abox/xls_pipeline_test/test_parser.py
@@ -209,8 +209,6 @@ def test_parser_excel(extension) -> None:
     expected_graph = Graph()
     expected_graph.parse(expected)
 
-    print(parser.graph.serialize(format="turtle"))
-
     assert parser.graph.isomorphic(expected_graph)
 
     assert parser.plain_metadata == metadata

--- a/tests/abox/xls_pipeline_test/test_parser.py
+++ b/tests/abox/xls_pipeline_test/test_parser.py
@@ -209,6 +209,8 @@ def test_parser_excel(extension) -> None:
     expected_graph = Graph()
     expected_graph.parse(expected)
 
+    print(parser.graph.serialize(format="turtle"))
+
     assert parser.graph.isomorphic(expected_graph)
 
     assert parser.plain_metadata == metadata

--- a/tests/tbox/csv_pipeline_test/output/output_csv_parser.ttl
+++ b/tests/tbox/csv_pipeline_test/output/output_csv_parser.ttl
@@ -16,7 +16,6 @@
     rdfs:label "B"^^xsd:string ;
     dcterms:contributor "John Doe"^^xsd:string ;
     dcterms:description "atio of the infinitesimal pressure increase to the resulting relative decrease of the volume"^^xsd:string ;
-    rdfs:comment ""^^xsd:string ;
     skos:altlabel "BulkModulus"^^xsd:string ;
     ns1:hasLabelSource "DIN EN ISO XXX"^^xsd:string ;
     ns1:hasTypicalUnitLabel "MPa "^^xsd:string .

--- a/tests/tbox/csv_pipeline_test/test_parser.py
+++ b/tests/tbox/csv_pipeline_test/test_parser.py
@@ -19,6 +19,7 @@ def test_parser_csv_tbox(extension) -> None:
     from rdflib import Graph
 
     from data2rdf.parsers import CSVParser
+    from data2rdf.warnings import MappingMissmatchWarning
 
     if isinstance(extension, str):
         mapping = os.path.join(mapping_folder, f"mapping.{extension}")
@@ -27,21 +28,30 @@ def test_parser_csv_tbox(extension) -> None:
         with open(path, encoding="utf-8") as file:
             mapping = json.load(file)
 
-    parser = CSVParser(
-        mode="tbox",
-        raw_data=raw_data,
-        mapping=mapping,
-        parser_args={
-            "column_sep": ";",
-            "suffix_location": "Ontological concept ID",
-            "ontology_title": "Test Ontology",
-            "authors": ["Jane Doe"],
-            "version_info": "1.0.0",
-        },
-        config={
-            "base_iri": "https://w3id.org/dimat",
-        },
-    )
+    with pytest.warns(
+        MappingMissmatchWarning, match="Data for key"
+    ) as warnings:
+        parser = CSVParser(
+            mode="tbox",
+            raw_data=raw_data,
+            mapping=mapping,
+            parser_args={
+                "column_sep": ";",
+                "suffix_location": "Ontological concept ID",
+                "ontology_title": "Test Ontology",
+                "authors": ["Jane Doe"],
+                "version_info": "1.0.0",
+            },
+            config={
+                "base_iri": "https://w3id.org/dimat",
+            },
+        )
+    missmatches = [
+        warning
+        for warning in warnings
+        if warning.category == MappingMissmatchWarning
+    ]
+    assert len(missmatches) == 1
 
     expected_graph = Graph()
     expected_graph.parse(expected)
@@ -54,6 +64,7 @@ def test_parser_csv_inputs_tbox(input_kind) -> None:
     from rdflib import Graph
 
     from data2rdf.parsers import CSVParser
+    from data2rdf.warnings import MappingMissmatchWarning
 
     mapping = os.path.join(mapping_folder, "mapping.json")
 
@@ -63,21 +74,30 @@ def test_parser_csv_inputs_tbox(input_kind) -> None:
         with open(raw_data, encoding="utf-8") as file:
             input_obj = file.read()
 
-    parser = CSVParser(
-        mode="tbox",
-        raw_data=input_obj,
-        mapping=mapping,
-        parser_args={
-            "column_sep": ";",
-            "suffix_location": "Ontological concept ID",
-            "ontology_title": "Test Ontology",
-            "authors": ["Jane Doe"],
-            "version_info": "1.0.0",
-        },
-        config={
-            "base_iri": "https://w3id.org/dimat",
-        },
-    )
+    with pytest.warns(
+        MappingMissmatchWarning, match="Data for key"
+    ) as warnings:
+        parser = CSVParser(
+            mode="tbox",
+            raw_data=input_obj,
+            mapping=mapping,
+            parser_args={
+                "column_sep": ";",
+                "suffix_location": "Ontological concept ID",
+                "ontology_title": "Test Ontology",
+                "authors": ["Jane Doe"],
+                "version_info": "1.0.0",
+            },
+            config={
+                "base_iri": "https://w3id.org/dimat",
+            },
+        )
+    missmatches = [
+        warning
+        for warning in warnings
+        if warning.category == MappingMissmatchWarning
+    ]
+    assert len(missmatches) == 1
 
     expected_graph = Graph()
     expected_graph.parse(expected)

--- a/tests/tbox/csv_pipeline_test/test_pipeline.py
+++ b/tests/tbox/csv_pipeline_test/test_pipeline.py
@@ -18,6 +18,8 @@ expected = os.path.join(output_folder, "output_csv_parser.ttl")
 def test_csv_pipeline_tbox(extension) -> None:
     from rdflib import Graph
 
+    from data2rdf.warnings import MappingMissmatchWarning
+
     from data2rdf import Data2RDF, Parser  # isort:skip
 
     if isinstance(extension, str):
@@ -28,22 +30,32 @@ def test_csv_pipeline_tbox(extension) -> None:
         with open(path, encoding="utf-8") as file:
             mapping = json.load(file)
 
-    pipeline = Data2RDF(
-        mode="tbox",
-        raw_data=raw_data,
-        mapping=mapping,
-        parser=Parser.csv,
-        parser_args={
-            "column_sep": ";",
-            "suffix_location": "Ontological concept ID",
-            "ontology_title": "Test Ontology",
-            "authors": ["Jane Doe"],
-            "version_info": "1.0.0",
-        },
-        config={
-            "base_iri": "https://w3id.org/dimat",
-        },
-    )
+    with pytest.warns(
+        MappingMissmatchWarning, match="Data for key"
+    ) as warnings:
+        pipeline = Data2RDF(
+            mode="tbox",
+            raw_data=raw_data,
+            mapping=mapping,
+            parser=Parser.csv,
+            parser_args={
+                "column_sep": ";",
+                "suffix_location": "Ontological concept ID",
+                "ontology_title": "Test Ontology",
+                "authors": ["Jane Doe"],
+                "version_info": "1.0.0",
+            },
+            config={
+                "base_iri": "https://w3id.org/dimat",
+            },
+        )
+
+    missmatches = [
+        warning
+        for warning in warnings
+        if warning.category == MappingMissmatchWarning
+    ]
+    assert len(missmatches) == 1
 
     expected_graph = Graph()
     expected_graph.parse(expected)
@@ -54,6 +66,8 @@ def test_csv_pipeline_tbox(extension) -> None:
 @pytest.mark.parametrize("input_kind", ["path", "content"])
 def test_csv_pipeline_inputs_tbox(input_kind) -> None:
     from rdflib import Graph
+
+    from data2rdf.warnings import MappingMissmatchWarning
 
     from data2rdf import (  # isort:skip
         Data2RDF,
@@ -66,22 +80,32 @@ def test_csv_pipeline_inputs_tbox(input_kind) -> None:
         with open(raw_data, encoding="utf-8") as file:
             input_obj = file.read()
 
-    pipeline = Data2RDF(
-        mode="tbox",
-        raw_data=input_obj,
-        mapping=os.path.join(mapping_folder, "mapping.json"),
-        parser=Parser.csv,
-        parser_args={
-            "column_sep": ";",
-            "suffix_location": "Ontological concept ID",
-            "ontology_title": "Test Ontology",
-            "authors": ["Jane Doe"],
-            "version_info": "1.0.0",
-        },
-        config={
-            "base_iri": "https://w3id.org/dimat",
-        },
-    )
+    with pytest.warns(
+        MappingMissmatchWarning, match="Data for key"
+    ) as warnings:
+        pipeline = Data2RDF(
+            mode="tbox",
+            raw_data=input_obj,
+            mapping=os.path.join(mapping_folder, "mapping.json"),
+            parser=Parser.csv,
+            parser_args={
+                "column_sep": ";",
+                "suffix_location": "Ontological concept ID",
+                "ontology_title": "Test Ontology",
+                "authors": ["Jane Doe"],
+                "version_info": "1.0.0",
+            },
+            config={
+                "base_iri": "https://w3id.org/dimat",
+            },
+        )
+
+    missmatches = [
+        warning
+        for warning in warnings
+        if warning.category == MappingMissmatchWarning
+    ]
+    assert len(missmatches) == 1
 
     expected_graph = Graph()
     expected_graph.parse(expected)

--- a/tests/tbox/explicit_datatypes/test_explicit_datatypes.py
+++ b/tests/tbox/explicit_datatypes/test_explicit_datatypes.py
@@ -5,37 +5,37 @@ import pytest
 DATA = [
     {
         "Ontological concept ID": "TestingMachine",
-        "Label": "Testing machine", 
+        "Label": "Testing machine",
         "Description": "Some description",
-        "Superclass": "owl:Thing", #TODO: This one is converted to a string.
+        "Superclass": "http://example.org#Object",
         "Comment": None,
-        "Source": 123, #TODO: This one is converted to a float. Why?
-        "Author's name": None, 
-        "Author's email": None
+        "Source": 123,
+        "Author's name": None,
+        "Author's email": None,
     },
     {
         "Ontological concept ID": "hasTestingMachine",
-        "Label": "has Testing machine", 
+        "Label": "has Testing machine",
         "Type": "owl:ObjectProperty",
-        "Description": "Some description", 
-        "Comment": None, 
-        "Source": None, 
-        "Author's name": None, 
-        "Author's email": None
-    }
+        "Description": "Some description",
+        "Comment": None,
+        "Source": None,
+        "Author's name": None,
+        "Author's email": None,
+    },
 ]
 
 
 MAPPING = [
     {
-        "key": "Label", 
-        "relation": "http://www.w3.org/2000/01/rdf-schema#label", 
-        "relation_type": "annotation_property", 
-     },
+        "key": "Label",
+        "relation": "http://www.w3.org/2000/01/rdf-schema#label",
+        "relation_type": "annotation_property",
+    },
     {
-        "key": "Description", 
-        "relation": "http://purl.org/dc/terms/description", 
-        "relation_type": "data_property", 
+        "key": "Description",
+        "relation": "http://purl.org/dc/terms/description",
+        "relation_type": "data_property",
     },
     {
         "key": "Superclass",
@@ -49,20 +49,20 @@ MAPPING = [
     },
     {
         "key": "Source",
-        "relation": "http://purl.org/dc/terms/source", 
-        "relation_type": "data_property", 
-        "datatype": "integer"
+        "relation": "http://purl.org/dc/terms/source",
+        "relation_type": "data_property",
+        "datatype": "integer",
     },
     {
         "key": "Author's name",
         "relation": "http://purl.org/dc/terms/contributor",
-        "relation_type": "data_property", 
+        "relation_type": "data_property",
     },
     {
         "key": "Author's email",
         "relation": "http://xmlns.com/foaf/0.1/mbox",
         "relation_type": "data_property",
-    }
+    },
 ]
 
 EXPECTED = """
@@ -82,25 +82,26 @@ EXPECTED = """
     rdfs:label "Testing machine"^^xsd:string ;
     dcterms:description "Some description"^^xsd:string ;
     dcterms:source "123"^^xsd:integer ;
-    rdfs:subClassOf owl:Thing .
+    rdfs:subClassOf <http://example.org#Object> .
 
 <https://w3id.org/dimat/hasTestingMachine> a owl:ObjectProperty ;
     rdfs:label "has Testing machine"^^xsd:string ;
     dcterms:description "Some description"^^xsd:string ."""
 
+
 def test_explicit_datatypes():
     from rdflib import Graph
+
+    from data2rdf.warnings import MappingMissmatchWarning
 
     from data2rdf import (  # isort:skip
         Data2RDF,
         Parser,
     )
-    from data2rdf.warnings import MappingMissmatchWarning    
 
     with pytest.warns(
         MappingMissmatchWarning, match="Data for key"
     ) as warnings:
-
         pipeline = Data2RDF(
             mode="tbox",
             raw_data=DATA,
@@ -125,7 +126,7 @@ def test_explicit_datatypes():
     ]
     assert len(missmatches) == 9
 
-    print(pipeline.graph.serialize(format="turtle")) #TODO: remove print
+    print(pipeline.graph.serialize(format="turtle"))  # TODO: remove print
 
     expected_graph = Graph()
     expected_graph.parse(data=EXPECTED)

--- a/tests/tbox/explicit_datatypes/test_explicit_datatypes.py
+++ b/tests/tbox/explicit_datatypes/test_explicit_datatypes.py
@@ -126,8 +126,6 @@ def test_explicit_datatypes():
     ]
     assert len(missmatches) == 9
 
-    print(pipeline.graph.serialize(format="turtle"))  # TODO: remove print
-
     expected_graph = Graph()
     expected_graph.parse(data=EXPECTED)
 

--- a/tests/tbox/explicit_datatypes/test_explicit_datatypes.py
+++ b/tests/tbox/explicit_datatypes/test_explicit_datatypes.py
@@ -1,0 +1,133 @@
+"""Test for explicit datatypes."""
+
+import pytest
+
+DATA = [
+    {
+        "Ontological concept ID": "TestingMachine",
+        "Label": "Testing machine", 
+        "Description": "Some description",
+        "Superclass": "owl:Thing", #TODO: This one is converted to a string.
+        "Comment": None,
+        "Source": 123, #TODO: This one is converted to a float. Why?
+        "Author's name": None, 
+        "Author's email": None
+    },
+    {
+        "Ontological concept ID": "hasTestingMachine",
+        "Label": "has Testing machine", 
+        "Type": "owl:ObjectProperty",
+        "Description": "Some description", 
+        "Comment": None, 
+        "Source": None, 
+        "Author's name": None, 
+        "Author's email": None
+    }
+]
+
+
+MAPPING = [
+    {
+        "key": "Label", 
+        "relation": "http://www.w3.org/2000/01/rdf-schema#label", 
+        "relation_type": "annotation_property", 
+     },
+    {
+        "key": "Description", 
+        "relation": "http://purl.org/dc/terms/description", 
+        "relation_type": "data_property", 
+    },
+    {
+        "key": "Superclass",
+        "relation": "http://www.w3.org/2000/01/rdf-schema#subClassOf",
+        "relation_type": "object_property",
+    },
+    {
+        "key": "Comment",
+        "relation": "http://www.w3.org/2000/01/rdf-schema#comment",
+        "relation_type": "data_property",
+    },
+    {
+        "key": "Source",
+        "relation": "http://purl.org/dc/terms/source", 
+        "relation_type": "data_property", 
+        "datatype": "integer"
+    },
+    {
+        "key": "Author's name",
+        "relation": "http://purl.org/dc/terms/contributor",
+        "relation_type": "data_property", 
+    },
+    {
+        "key": "Author's email",
+        "relation": "http://xmlns.com/foaf/0.1/mbox",
+        "relation_type": "data_property",
+    }
+]
+
+EXPECTED = """
+@prefix dcterms: <http://purl.org/dc/terms/> .
+@prefix foaf1: <http://xmlns.com/foaf/spec/> .
+@prefix owl: <http://www.w3.org/2002/07/owl#> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+
+<https://w3id.org/dimat> a owl:Ontology ;
+    dcterms:creator [ a foaf1:Person ;
+            foaf1:name "Jane Doe" ] ;
+    dcterms:title "Test Ontology" ;
+    owl:versionInfo "1.0.0" .
+
+<https://w3id.org/dimat/TestingMachine> a owl:Class ;
+    rdfs:label "Testing machine"^^xsd:string ;
+    dcterms:description "Some description"^^xsd:string ;
+    dcterms:source "123"^^xsd:integer ;
+    rdfs:subClassOf owl:Thing .
+
+<https://w3id.org/dimat/hasTestingMachine> a owl:ObjectProperty ;
+    rdfs:label "has Testing machine"^^xsd:string ;
+    dcterms:description "Some description"^^xsd:string ."""
+
+def test_explicit_datatypes():
+    from rdflib import Graph
+
+    from data2rdf import (  # isort:skip
+        Data2RDF,
+        Parser,
+    )
+    from data2rdf.warnings import MappingMissmatchWarning    
+
+    with pytest.warns(
+        MappingMissmatchWarning, match="Data for key"
+    ) as warnings:
+
+        pipeline = Data2RDF(
+            mode="tbox",
+            raw_data=DATA,
+            mapping=MAPPING,
+            parser=Parser.json,
+            parser_args={
+                "suffix_location": "Ontological concept ID",
+                "rdfs_type_location": "Type",
+                "ontology_title": "Test Ontology",
+                "authors": ["Jane Doe"],
+                "version_info": "1.0.0",
+            },
+            config={
+                "base_iri": "https://w3id.org/dimat",
+            },
+        )
+
+    missmatches = [
+        warning
+        for warning in warnings
+        if warning.category == MappingMissmatchWarning
+    ]
+    assert len(missmatches) == 9
+
+    print(pipeline.graph.serialize(format="turtle")) #TODO: remove print
+
+    expected_graph = Graph()
+    expected_graph.parse(data=EXPECTED)
+
+    assert pipeline.graph.isomorphic(expected_graph)

--- a/tests/tbox/explicit_datatypes/test_explicit_datatypes.py
+++ b/tests/tbox/explicit_datatypes/test_explicit_datatypes.py
@@ -51,7 +51,7 @@ MAPPING = [
         "key": "Source",
         "relation": "http://purl.org/dc/terms/source",
         "relation_type": "data_property",
-        "datatype": "integer",
+        "datatype": "float",
     },
     {
         "key": "Author's name",
@@ -81,7 +81,7 @@ EXPECTED = """
 <https://w3id.org/dimat/TestingMachine> a owl:Class ;
     rdfs:label "Testing machine"^^xsd:string ;
     dcterms:description "Some description"^^xsd:string ;
-    dcterms:source "123"^^xsd:integer ;
+    dcterms:source "123.0"^^xsd:float ;
     rdfs:subClassOf <http://example.org#Object> .
 
 <https://w3id.org/dimat/hasTestingMachine> a owl:ObjectProperty ;

--- a/tests/tbox/json_pipeline_test/output/output_json_parser.ttl
+++ b/tests/tbox/json_pipeline_test/output/output_json_parser.ttl
@@ -16,7 +16,6 @@
     rdfs:label "B"^^xsd:string ;
     dcterms:contributor "John Doe"^^xsd:string ;
     dcterms:description "atio of the infinitesimal pressure increase to the resulting relative decrease of the volume"^^xsd:string ;
-    rdfs:comment ""^^xsd:string ;
     skos:altlabel "BulkModulus"^^xsd:string ;
     ns1:hasLabelSource "DIN EN ISO XXX"^^xsd:string ;
     ns1:hasTypicalUnitLabel "MPa "^^xsd:string .

--- a/tests/tbox/json_pipeline_test/output/output_json_parser_wo_title.ttl
+++ b/tests/tbox/json_pipeline_test/output/output_json_parser_wo_title.ttl
@@ -10,7 +10,6 @@
     rdfs:label "B"^^xsd:string ;
     dcterms:contributor "John Doe"^^xsd:string ;
     dcterms:description "atio of the infinitesimal pressure increase to the resulting relative decrease of the volume"^^xsd:string ;
-    rdfs:comment ""^^xsd:string ;
     skos:altlabel "BulkModulus"^^xsd:string ;
     ns1:hasLabelSource "DIN EN ISO XXX"^^xsd:string ;
     ns1:hasTypicalUnitLabel "MPa "^^xsd:string .

--- a/tests/tbox/json_pipeline_test/test_parser.py
+++ b/tests/tbox/json_pipeline_test/test_parser.py
@@ -19,6 +19,7 @@ def test_parser_json_tbox(extension) -> None:
     from rdflib import Graph
 
     from data2rdf.parsers import JsonParser
+    from data2rdf.warnings import MappingMissmatchWarning
 
     if isinstance(extension, str):
         mapping = os.path.join(mapping_folder, f"mapping.{extension}")
@@ -27,20 +28,30 @@ def test_parser_json_tbox(extension) -> None:
         with open(path, encoding="utf-8") as file:
             mapping = json.load(file)
 
-    parser = JsonParser(
-        mode="tbox",
-        raw_data=raw_data,
-        mapping=mapping,
-        parser_args={
-            "suffix_location": "Ontological concept ID",
-            "ontology_title": "Test Ontology",
-            "authors": ["Jane Doe"],
-            "version_info": "1.0.0",
-        },
-        config={
-            "base_iri": "https://w3id.org/dimat",
-        },
-    )
+    with pytest.warns(
+        MappingMissmatchWarning, match="Data for key"
+    ) as warnings:
+        parser = JsonParser(
+            mode="tbox",
+            raw_data=raw_data,
+            mapping=mapping,
+            parser_args={
+                "suffix_location": "Ontological concept ID",
+                "ontology_title": "Test Ontology",
+                "authors": ["Jane Doe"],
+                "version_info": "1.0.0",
+            },
+            config={
+                "base_iri": "https://w3id.org/dimat",
+            },
+        )
+
+    missmatches = [
+        warning
+        for warning in warnings
+        if warning.category == MappingMissmatchWarning
+    ]
+    assert len(missmatches) == 1
 
     expected_graph = Graph()
     expected_graph.parse(expected)
@@ -53,6 +64,7 @@ def test_parser_json_inputs_tbox(input_kind) -> None:
     from rdflib import Graph
 
     from data2rdf.parsers import JsonParser
+    from data2rdf.warnings import MappingMissmatchWarning
 
     mapping = os.path.join(mapping_folder, "mapping.json")
 
@@ -62,20 +74,30 @@ def test_parser_json_inputs_tbox(input_kind) -> None:
         with open(raw_data, encoding="utf-8") as file:
             input_obj = file.read()
 
-    parser = JsonParser(
-        mode="tbox",
-        raw_data=input_obj,
-        mapping=mapping,
-        parser_args={
-            "suffix_location": "Ontological concept ID",
-            "ontology_title": "Test Ontology",
-            "authors": ["Jane Doe"],
-            "version_info": "1.0.0",
-        },
-        config={
-            "base_iri": "https://w3id.org/dimat",
-        },
-    )
+    with pytest.warns(
+        MappingMissmatchWarning, match="Data for key"
+    ) as warnings:
+        parser = JsonParser(
+            mode="tbox",
+            raw_data=input_obj,
+            mapping=mapping,
+            parser_args={
+                "suffix_location": "Ontological concept ID",
+                "ontology_title": "Test Ontology",
+                "authors": ["Jane Doe"],
+                "version_info": "1.0.0",
+            },
+            config={
+                "base_iri": "https://w3id.org/dimat",
+            },
+        )
+
+    missmatches = [
+        warning
+        for warning in warnings
+        if warning.category == MappingMissmatchWarning
+    ]
+    assert len(missmatches) == 1
 
     expected_graph = Graph()
     expected_graph.parse(expected)

--- a/tests/tbox/json_pipeline_test/test_pipeline.py
+++ b/tests/tbox/json_pipeline_test/test_pipeline.py
@@ -18,6 +18,8 @@ expected = os.path.join(output_folder, "output_json_parser.ttl")
 def test_json_pipeline_tbox(extension) -> None:
     from rdflib import Graph
 
+    from data2rdf.warnings import MappingMissmatchWarning
+
     from data2rdf import Data2RDF, Parser  # isort:skip
 
     if isinstance(extension, str):
@@ -28,21 +30,31 @@ def test_json_pipeline_tbox(extension) -> None:
         with open(path, encoding="utf-8") as file:
             mapping = json.load(file)
 
-    pipeline = Data2RDF(
-        mode="tbox",
-        raw_data=raw_data,
-        mapping=mapping,
-        parser=Parser.json,
-        parser_args={
-            "suffix_location": "Ontological concept ID",
-            "ontology_title": "Test Ontology",
-            "authors": ["Jane Doe"],
-            "version_info": "1.0.0",
-        },
-        config={
-            "base_iri": "https://w3id.org/dimat",
-        },
-    )
+    with pytest.warns(
+        MappingMissmatchWarning, match="Data for key"
+    ) as warnings:
+        pipeline = Data2RDF(
+            mode="tbox",
+            raw_data=raw_data,
+            mapping=mapping,
+            parser=Parser.json,
+            parser_args={
+                "suffix_location": "Ontological concept ID",
+                "ontology_title": "Test Ontology",
+                "authors": ["Jane Doe"],
+                "version_info": "1.0.0",
+            },
+            config={
+                "base_iri": "https://w3id.org/dimat",
+            },
+        )
+
+    missmatches = [
+        warning
+        for warning in warnings
+        if warning.category == MappingMissmatchWarning
+    ]
+    assert len(missmatches) == 1
 
     expected_graph = Graph()
     expected_graph.parse(expected)
@@ -53,6 +65,8 @@ def test_json_pipeline_tbox(extension) -> None:
 @pytest.mark.parametrize("input_kind", ["path", "content"])
 def test_json_pipeline_inputs_tbox(input_kind) -> None:
     from rdflib import Graph
+
+    from data2rdf.warnings import MappingMissmatchWarning
 
     from data2rdf import (  # isort:skip
         Data2RDF,
@@ -65,21 +79,31 @@ def test_json_pipeline_inputs_tbox(input_kind) -> None:
         with open(raw_data, encoding="utf-8") as file:
             input_obj = file.read()
 
-    pipeline = Data2RDF(
-        mode="tbox",
-        raw_data=input_obj,
-        mapping=os.path.join(mapping_folder, "mapping.json"),
-        parser=Parser.json,
-        parser_args={
-            "suffix_location": "Ontological concept ID",
-            "ontology_title": "Test Ontology",
-            "authors": ["Jane Doe"],
-            "version_info": "1.0.0",
-        },
-        config={
-            "base_iri": "https://w3id.org/dimat",
-        },
-    )
+    with pytest.warns(
+        MappingMissmatchWarning, match="Data for key"
+    ) as warnings:
+        pipeline = Data2RDF(
+            mode="tbox",
+            raw_data=input_obj,
+            mapping=os.path.join(mapping_folder, "mapping.json"),
+            parser=Parser.json,
+            parser_args={
+                "suffix_location": "Ontological concept ID",
+                "ontology_title": "Test Ontology",
+                "authors": ["Jane Doe"],
+                "version_info": "1.0.0",
+            },
+            config={
+                "base_iri": "https://w3id.org/dimat",
+            },
+        )
+
+    missmatches = [
+        warning
+        for warning in warnings
+        if warning.category == MappingMissmatchWarning
+    ]
+    assert len(missmatches) == 1
 
     expected_graph = Graph()
     expected_graph.parse(expected)

--- a/tests/tbox/json_pipeline_test/test_title_exclusion.py
+++ b/tests/tbox/json_pipeline_test/test_title_exclusion.py
@@ -3,6 +3,8 @@
 import json
 import os
 
+import pytest
+
 test_folder = os.path.dirname(os.path.abspath(__file__))
 working_folder = os.path.join(test_folder, "input")
 output_folder = os.path.join(test_folder, "output")
@@ -15,25 +17,37 @@ expected = os.path.join(output_folder, "output_json_parser_wo_title.ttl")
 def test_json_pipeline_tbox_wo_title() -> None:
     from rdflib import Graph
 
+    from data2rdf.warnings import MappingMissmatchWarning
+
     from data2rdf import Data2RDF, Parser  # isort:skip
 
     path = os.path.join(mapping_folder, "mapping.json")
     with open(path, encoding="utf-8") as file:
         mapping = json.load(file)
 
-    pipeline = Data2RDF(
-        mode="tbox",
-        raw_data=raw_data,
-        mapping=mapping,
-        parser=Parser.json,
-        parser_args={
-            "suffix_location": "Ontological concept ID",
-        },
-        config={
-            "base_iri": "https://w3id.org/dimat",
-            "exclude_ontology_title": True,
-        },
-    )
+    with pytest.warns(
+        MappingMissmatchWarning, match="Data for key"
+    ) as warnings:
+        pipeline = Data2RDF(
+            mode="tbox",
+            raw_data=raw_data,
+            mapping=mapping,
+            parser=Parser.json,
+            parser_args={
+                "suffix_location": "Ontological concept ID",
+            },
+            config={
+                "base_iri": "https://w3id.org/dimat",
+                "exclude_ontology_title": True,
+            },
+        )
+
+    missmatches = [
+        warning
+        for warning in warnings
+        if warning.category == MappingMissmatchWarning
+    ]
+    assert len(missmatches) == 1
 
     expected_graph = Graph()
     expected_graph.parse(expected)

--- a/tests/tbox/xls_pipeline_test/output/output_excel_parser.ttl
+++ b/tests/tbox/xls_pipeline_test/output/output_excel_parser.ttl
@@ -16,7 +16,6 @@
     rdfs:label "B"^^xsd:string ;
     dcterms:contributor "John Doe"^^xsd:string ;
     dcterms:description "atio of the infinitesimal pressure increase to the resulting relative decrease of the volume"^^xsd:string ;
-    rdfs:comment ""^^xsd:string ;
     skos:altlabel "BulkModulus"^^xsd:string ;
     ns1:hasLabelSource "DIN EN ISO XXX"^^xsd:string ;
     ns1:hasTypicalUnitLabel "MPa "^^xsd:string .

--- a/tests/tbox/xls_pipeline_test/test_parser.py
+++ b/tests/tbox/xls_pipeline_test/test_parser.py
@@ -19,6 +19,7 @@ def test_parser_excel_tbox(extension) -> None:
     from rdflib import Graph
 
     from data2rdf.parsers import ExcelParser
+    from data2rdf.warnings import MappingMissmatchWarning
 
     if isinstance(extension, str):
         mapping = os.path.join(mapping_folder, f"mapping.{extension}")
@@ -27,21 +28,31 @@ def test_parser_excel_tbox(extension) -> None:
         with open(path, encoding="utf-8") as file:
             mapping = json.load(file)
 
-    parser = ExcelParser(
-        mode="tbox",
-        raw_data=raw_data,
-        mapping=mapping,
-        parser_args={
-            "sheet": "Sheet1",
-            "suffix_location": "Ontological concept ID",
-            "ontology_title": "Test Ontology",
-            "authors": ["Jane Doe"],
-            "version_info": "1.0.0",
-        },
-        config={
-            "base_iri": "https://w3id.org/dimat",
-        },
-    )
+    with pytest.warns(
+        MappingMissmatchWarning, match="Data for key"
+    ) as warnings:
+        parser = ExcelParser(
+            mode="tbox",
+            raw_data=raw_data,
+            mapping=mapping,
+            parser_args={
+                "sheet": "Sheet1",
+                "suffix_location": "Ontological concept ID",
+                "ontology_title": "Test Ontology",
+                "authors": ["Jane Doe"],
+                "version_info": "1.0.0",
+            },
+            config={
+                "base_iri": "https://w3id.org/dimat",
+            },
+        )
+
+    missmatches = [
+        warning
+        for warning in warnings
+        if warning.category == MappingMissmatchWarning
+    ]
+    assert len(missmatches) == 1
 
     expected_graph = Graph()
     expected_graph.parse(expected)
@@ -54,6 +65,7 @@ def test_parser_excel_inputs_tbox(input_kind) -> None:
     from rdflib import Graph
 
     from data2rdf.parsers import ExcelParser
+    from data2rdf.warnings import MappingMissmatchWarning
 
     mapping = os.path.join(mapping_folder, "mapping.json")
 
@@ -63,21 +75,31 @@ def test_parser_excel_inputs_tbox(input_kind) -> None:
         with open(raw_data, "rb") as file:
             input_obj = file.read()
 
-    parser = ExcelParser(
-        mode="tbox",
-        raw_data=input_obj,
-        mapping=mapping,
-        parser_args={
-            "sheet": "Sheet1",
-            "suffix_location": "Ontological concept ID",
-            "ontology_title": "Test Ontology",
-            "authors": ["Jane Doe"],
-            "version_info": "1.0.0",
-        },
-        config={
-            "base_iri": "https://w3id.org/dimat",
-        },
-    )
+    with pytest.warns(
+        MappingMissmatchWarning, match="Data for key"
+    ) as warnings:
+        parser = ExcelParser(
+            mode="tbox",
+            raw_data=input_obj,
+            mapping=mapping,
+            parser_args={
+                "sheet": "Sheet1",
+                "suffix_location": "Ontological concept ID",
+                "ontology_title": "Test Ontology",
+                "authors": ["Jane Doe"],
+                "version_info": "1.0.0",
+            },
+            config={
+                "base_iri": "https://w3id.org/dimat",
+            },
+        )
+
+    missmatches = [
+        warning
+        for warning in warnings
+        if warning.category == MappingMissmatchWarning
+    ]
+    assert len(missmatches) == 1
 
     expected_graph = Graph()
     expected_graph.parse(expected)

--- a/tests/tbox/xls_pipeline_test/test_pipeline.py
+++ b/tests/tbox/xls_pipeline_test/test_pipeline.py
@@ -18,6 +18,8 @@ expected = os.path.join(output_folder, "output_excel_parser.ttl")
 def test_excel_pipeline_tbox(extension) -> None:
     from rdflib import Graph
 
+    from data2rdf.warnings import MappingMissmatchWarning
+
     from data2rdf import Data2RDF, Parser  # isort:skip
 
     if isinstance(extension, str):
@@ -28,22 +30,32 @@ def test_excel_pipeline_tbox(extension) -> None:
         with open(path, encoding="utf-8") as file:
             mapping = json.load(file)
 
-    pipeline = Data2RDF(
-        mode="tbox",
-        raw_data=raw_data,
-        mapping=mapping,
-        parser=Parser.excel,
-        parser_args={
-            "sheet": "Sheet1",
-            "suffix_location": "Ontological concept ID",
-            "ontology_title": "Test Ontology",
-            "authors": ["Jane Doe"],
-            "version_info": "1.0.0",
-        },
-        config={
-            "base_iri": "https://w3id.org/dimat",
-        },
-    )
+    with pytest.warns(
+        MappingMissmatchWarning, match="Data for key"
+    ) as warnings:
+        pipeline = Data2RDF(
+            mode="tbox",
+            raw_data=raw_data,
+            mapping=mapping,
+            parser=Parser.excel,
+            parser_args={
+                "sheet": "Sheet1",
+                "suffix_location": "Ontological concept ID",
+                "ontology_title": "Test Ontology",
+                "authors": ["Jane Doe"],
+                "version_info": "1.0.0",
+            },
+            config={
+                "base_iri": "https://w3id.org/dimat",
+            },
+        )
+
+    missmatches = [
+        warning
+        for warning in warnings
+        if warning.category == MappingMissmatchWarning
+    ]
+    assert len(missmatches) == 1
 
     expected_graph = Graph()
     expected_graph.parse(expected)
@@ -54,6 +66,8 @@ def test_excel_pipeline_tbox(extension) -> None:
 @pytest.mark.parametrize("input_kind", ["path", "content"])
 def test_excel_pipeline_inputs_tbox(input_kind) -> None:
     from rdflib import Graph
+
+    from data2rdf.warnings import MappingMissmatchWarning
 
     from data2rdf import (  # isort:skip
         Data2RDF,
@@ -66,22 +80,32 @@ def test_excel_pipeline_inputs_tbox(input_kind) -> None:
         with open(raw_data, "rb") as file:
             input_obj = file.read()
 
-    pipeline = Data2RDF(
-        mode="tbox",
-        raw_data=input_obj,
-        mapping=os.path.join(mapping_folder, "mapping.json"),
-        parser=Parser.excel,
-        parser_args={
-            "sheet": "Sheet1",
-            "suffix_location": "Ontological concept ID",
-            "ontology_title": "Test Ontology",
-            "authors": ["Jane Doe"],
-            "version_info": "1.0.0",
-        },
-        config={
-            "base_iri": "https://w3id.org/dimat",
-        },
-    )
+    with pytest.warns(
+        MappingMissmatchWarning, match="Data for key"
+    ) as warnings:
+        pipeline = Data2RDF(
+            mode="tbox",
+            raw_data=input_obj,
+            mapping=os.path.join(mapping_folder, "mapping.json"),
+            parser=Parser.excel,
+            parser_args={
+                "sheet": "Sheet1",
+                "suffix_location": "Ontological concept ID",
+                "ontology_title": "Test Ontology",
+                "authors": ["Jane Doe"],
+                "version_info": "1.0.0",
+            },
+            config={
+                "base_iri": "https://w3id.org/dimat",
+            },
+        )
+
+    missmatches = [
+        warning
+        for warning in warnings
+        if warning.category == MappingMissmatchWarning
+    ]
+    assert len(missmatches) == 1
 
     expected_graph = Graph()
     expected_graph.parse(expected)


### PR DESCRIPTION
With the follow PR, we will have the support for the following functionalities:

* multiple class types for individuals in the ABox
* explicit datatyping for the Tbox relations
* ignoring of null/None-valued objects in the input data
* fixes in the object property serialization (from "" to <>)

_____

Let us assume the following input data for a TBox generation:

```{python}
[
    {
        "Ontological concept ID": "TestingMachine",
        "Label": "Testing machine",
        "Description": "Some description",
        "Superclass": "http://example.org#Object", # note that this is a URI
        "Comment": None, # note that this is none
        "Source": 123,
        "Author's name": None,
        "Author's email": None,
    },
    {
        "Ontological concept ID": "hasTestingMachine",
        "Label": "has Testing machine",
        "Type": "owl:ObjectProperty",
        "Description": "Some description",
        "Comment": None,
        "Source": None,
        "Author's name": None,
        "Author's email": None,
    },
]
```
The corresponding mapping looks like this:

```{python}
 [
    {
        "key": "Label",
        "relation": "http://www.w3.org/2000/01/rdf-schema#label",
        "relation_type": "annotation_property",
    },
    {
        "key": "Description",
        "relation": "http://purl.org/dc/terms/description",
        "relation_type": "data_property",
    },
    {
        "key": "Superclass",
        "relation": "http://www.w3.org/2000/01/rdf-schema#subClassOf",
        "relation_type": "object_property", # note the relation typing here
    },
    {
        "key": "Comment",
        "relation": "http://www.w3.org/2000/01/rdf-schema#comment",
        "relation_type": "data_property",
    },
    {
        "key": "Source",
        "relation": "http://purl.org/dc/terms/source",
        "relation_type": "data_property",
        "datatype": "float", # note the datatyping here
    },
    {
        "key": "Author's name",
        "relation": "http://purl.org/dc/terms/contributor",
        "relation_type": "data_property",
    },
    {
        "key": "Author's email",
        "relation": "http://xmlns.com/foaf/0.1/mbox",
        "relation_type": "data_property",
    },
]
```


The resulting graph will look like this:
```
@prefix dcterms: <http://purl.org/dc/terms/> .
@prefix foaf1: <http://xmlns.com/foaf/spec/> .
@prefix owl: <http://www.w3.org/2002/07/owl#> .
@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .

<https://w3id.org/dimat> a owl:Ontology ;
    dcterms:creator [ a foaf1:Person ;
            foaf1:name "Jane Doe" ] ;
    dcterms:title "Test Ontology" ;
    owl:versionInfo "1.0.0" .

<https://w3id.org/dimat/TestingMachine> a owl:Class ;
    rdfs:label "Testing machine"^^xsd:string ;
    dcterms:description "Some description"^^xsd:string ;
    dcterms:source "123.0"^^xsd:float ;
    rdfs:subClassOf <http://example.org#Object> .

<https://w3id.org/dimat/hasTestingMachine> a owl:ObjectProperty ;
    rdfs:label "has Testing machine"^^xsd:string ;
    dcterms:description "Some description"^^xsd:string .
    
```