### PR TITLE
bump gh actions for artifacts v3->v4

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -35,7 +35,7 @@ jobs:
                   --outdir dist/
 
             - name: Upload distribution artifact
-              uses: actions/upload-artifact@v3
+              uses: actions/upload-artifact@v4
               with:
                   name: release
                   path: dist/
@@ -46,7 +46,7 @@ jobs:
         runs-on: ubuntu-latest
 
         steps:
-            - uses: actions/download-artifact@v3
+            - uses: actions/download-artifact@v4
               name: Download distribution artifact
               with:
                   name: release


### PR DESCRIPTION
gh actions v3 for download/upload artifacts is no longer available.